### PR TITLE
Create new Merchant Item feature

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -29,7 +29,19 @@ class MerchantItemsController < ApplicationController
     end
   end
 
+  def new
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def create
+    merchant = Merchant.find(params[:merchant_id])
+    merchant.items.create(item_params)
+
+    redirect_to "/merchants/#{merchant.id}/items"
+  end
+
   private
+
   def item_params
     params.permit(:name, :description, :unit_price, :status)
   end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,5 @@
 <% @merchant.items.each do |item| %>
-  <div id="item-<%= item.id %>">  
+  <div id="item-<%= item.id %>">
     <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
     <% if item.status == "disabled" %>
       <%= button_to "Enable" ,"/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, local: true, params: {status: "enabled"} %>
@@ -8,3 +8,5 @@
     <% end  %>
   </div>
 <% end %>
+
+<%= link_to "Add New Item", "/merchants/#{@merchant.id}/items/new" %>

--- a/app/views/merchant_items/new.html.erb
+++ b/app/views/merchant_items/new.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |form| %>
+<%= form.label :name %>
+<%= form.text_field :name %>
+<%= form.label :description %>
+<%= form.text_field :description %>
+<%= form.label :unit_price %>
+<%= form.text_field :unit_price %>
+<%= form.submit "Submit"%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :merchants do
     resources :dashboard, only: [:index]
     get '/items', to: 'merchant_items#index'
+    get '/items/new', to: 'merchant_items#new'
+    post '/items', to: 'merchant_items#create'
     get '/items/:id', to: 'merchant_items#show'
     get '/items/:id/edit', to: 'merchant_items#edit'
     patch 'items/:id', to: 'merchant_items#update'

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "New Item Creation" do
+  it 'has a link from the merchant item index page' do
+    merchant_1 = Merchant.create!(name: "Clothing Store")
+
+    visit "/merchants/#{merchant_1.id}/items"
+
+    click_link "Add New Item"
+
+    expect(current_path).to eq("/merchants/#{merchant_1.id}/items/new")
+  end
+
+  it 'can create a new item' do
+    merchant_1 = Merchant.create!(name: "Clothing Store")
+    item_1 = merchant_1.items.create!(name: "Sweater", description: "Red Sweater", unit_price: 40)
+    item_2 = merchant_1.items.create!(name: "Hat", description: "Beanie", unit_price: 20, status: 1)
+    item_3 = merchant_1.items.create!(name: "Shoes", description: "Running Shoes", unit_price: 80)
+
+    visit "/merchants/#{merchant_1.id}/items/new"
+
+    fill_in('Name' , with: "Sweet T-Shirt")
+    fill_in('Description' , with: "Blue T-shirt with Logo")
+    fill_in('Unit price', with: 25)
+
+    click_on("Submit")
+
+    expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
+
+    visit "/merchants/#{merchant_1.id}/items"
+    
+    new_item = Item.last
+    expect(new_item.name).to eq("Sweet T-Shirt")
+    expect(page).to have_content(new_item.name)
+    expect(new_item.status).to eq("disabled")
+  end
+end


### PR DESCRIPTION
Added link to merchant item index page to create a new item for the merchant.  When link is clicked merchant-user is taken to a form to create a new item.  When form is submitted, you are redirected to the merchant item index page where the new item shows up.