### PR TITLE
Adm merchant create

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -12,6 +12,11 @@ class Admin::MerchantsController < ApplicationController
     @merchant = Merchant.find(params[:id])
   end
 
+  def create
+    Merchant.create!(name: params[:name])
+    redirect_to "/admin/merchants"
+  end
+
   def update
     merchant = Merchant.find(params[:id])
     if params[:merchant][:status] == "enabled"

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,7 @@
 <h1>ADMIN: MERCHANTS</h1>
 
+<%= link_to "Create a New Merchant", new_admin_merchant_path %>
+
 <div id="enabled-merchants">
 <h3>Enabled Merchants:</h3><hr>
   <% @enabled_merchants.each do |merchant| %>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Create a New Merchant</h1>
+
+<%= form_with url: "/admin/merchants", method: :post, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.submit "Create Merchant" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'admin#index'
-    resources :merchants, only: [:index, :show, :edit, :update]
+    resources :merchants, only: [:index, :new, :show, :edit, :update]
     resources :invoices, only: [:index, :show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'admin#index'
-    resources :merchants, only: [:index, :new, :show, :edit, :update]
+    resources :merchants, only: [:index, :new, :show, :create, :edit, :update]
     resources :invoices, only: [:index, :show]
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -63,4 +63,8 @@ RSpec.describe 'admin merchants index' do
       expect(page).to_not have_content(merchant_3.name)
     end
   end
+
+  it 'has a link to create a new merchant on a new page' do
+    expect(page).to have_link("Create a New Merchant", href: "/admin/merchants/new")
+  end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'New Merchant Creation' do
+  describe 'when I click on the link to create a new merchant' do
+    it 'links to a new page where a new merchant can be created via a form' do
+      visit '/admin/merchants'
+
+      click_link('Create a New Merchant')
+      expect(current_path).to eq('/admin/merchants/new')
+    end
+
+    it 'can create a new merchant' do
+      visit '/admin/merchants/new'
+
+      fill_in(:name, with: 'TEsty Merchant')
+      click_button('Create Merchant')
+
+      expect(current_path).to eq('/admin/merchants')
+      expect(page).to have_content('TEsty Merchant')
+    end
+  end
+end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe 'New Merchant Creation' do
 
     it 'can create a new merchant' do
       visit '/admin/merchants/new'
-
-      fill_in(:name, with: 'TEsty Merchant')
+      fill_in('Name', with: 'TEsty Merchant')
       click_button('Create Merchant')
 
       expect(current_path).to eq('/admin/merchants')

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Customer, type: :model do
   describe "instance methods" do
     let!(:customer_1) {FactoryBot.create(:customer)}
     let!(:invoice_1) {FactoryBot.create(:invoice, customer: customer_1)}
-    let!(:transaction_1) {FactoryBot.create(:transaction, invoice: invoice_1)}
-    let!(:transaction_2) {FactoryBot.create(:transaction, invoice: invoice_1)}
-    let!(:transaction_3) {FactoryBot.create(:transaction, invoice: invoice_1)}
-    let!(:transaction_4) {FactoryBot.create(:transaction, invoice: invoice_1)}
+    let!(:transaction_1) {FactoryBot.create(:transaction, result: "success", invoice: invoice_1)}
+    let!(:transaction_2) {FactoryBot.create(:transaction, result: "success", invoice: invoice_1)}
+    let!(:transaction_3) {FactoryBot.create(:transaction, result: "success", invoice: invoice_1)}
+    let!(:transaction_4) {FactoryBot.create(:transaction, result: "success", invoice: invoice_1)}
     describe '#transaction_count' do
       it 'returns number of transaction for customer' do
         expect(customer_1.transaction_count).to eq(4)


### PR DESCRIPTION
This is the User Story to create a new merchant from the admin merchants index page.
This includes a link from the merchants index to create a new merchant where you're taken to a new form.  You can enter the name of a new merchant, click create, and youre taken back to the merchants index where you can see the new merchant.

I additionally created this with the `form_with model:` but it was not working so I changed it back for `form_with url:` for now.

I also updated some of my tests in `customer_spec.rb` for a previous user story.