### PR TITLE
Jmg bug fix

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,6 +31,6 @@ class Invoice < ApplicationRecord
   end
 
   def self.incomplete
-    joins(:invoice_items).where.not(invoice_items: { status: 2 }).order(:created_at)
+    joins(:invoice_items).where.not(invoice_items: { status: 2 }).order(:created_at).uniq
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -17,7 +17,7 @@
   <% @merchant.ready_items.each do |item| %>
     <p><div id="merchants-item-<%= item.name %>">
       <%= item.name %>
-      <%= link_to item.invoices.first.id, "/merchants/#{@merchant.id}/invoices" %>
+      <%= link_to item.invoices.first.id, "/merchants/#{@merchant.id}/invoices/#{item.invoices.first.id}" %>
       <%= item.date_created %>
     </div></p>
   <% end %>

--- a/spec/features/admin/admin/index_spec.rb
+++ b/spec/features/admin/admin/index_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe 'admin index page' do
   end
 
   it 'has invoices which are all links to that invoices admin show page' do
-    expect(page).to have_link(invoice_item_1.invoice.id, href: "/admin/invoices/#{invoice_item_1.invoice.id}")
-    expect(page).to have_link(invoice_item_2.invoice.id, href: "/admin/invoices/#{invoice_item_2.invoice.id}")
+    expect(page).to have_link("#{invoice_item_1.invoice.id}", href: "/admin/invoices/#{invoice_item_1.invoice.id}")
+    expect(page).to have_link("#{invoice_item_2.invoice.id}", href: "/admin/invoices/#{invoice_item_2.invoice.id}")
   end
 
   it 'lists the invoices displays the date they were created' do

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -141,17 +141,17 @@ RSpec.describe 'Merchant Dashboard' do
   it 'has the invoice id as a link next to the item name' do
     within "#merchants-item-#{@item3.name}" do
       expect(page).to have_content(@item3.invoices.first.id)
-      expect(page).to have_link(@item3.invoices.first.id, href: "/merchants/#{@merchant.id}/invoices")
+      expect(page).to have_link("#{@item3.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices/#{@item3.invoices.first.id}")
     end
 
     within "#merchants-item-#{@item4.name}" do
       expect(page).to have_content(@item4.invoices.first.id)
-      expect(page).to have_link(@item4.invoices.first.id, href: "/merchants/#{@merchant.id}/invoices")
+      expect(page).to have_link("#{@item4.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices")
     end
 
     within "#merchants-item-#{@item5.name}" do
       expect(page).to have_content(@item5.invoices.first.id)
-      expect(page).to have_link(@item5.invoices.first.id, href: "/merchants/#{@merchant.id}/invoices")
+      expect(page).to have_link("#{@item5.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices")
     end
   end
 

--- a/spec/features/merchants/dashboard/index_spec.rb
+++ b/spec/features/merchants/dashboard/index_spec.rb
@@ -146,12 +146,12 @@ RSpec.describe 'Merchant Dashboard' do
 
     within "#merchants-item-#{@item4.name}" do
       expect(page).to have_content(@item4.invoices.first.id)
-      expect(page).to have_link("#{@item4.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices")
+      expect(page).to have_link("#{@item4.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices/#{@item4.invoices.first.id}")
     end
 
     within "#merchants-item-#{@item5.name}" do
       expect(page).to have_content(@item5.invoices.first.id)
-      expect(page).to have_link("#{@item5.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices")
+      expect(page).to have_link("#{@item5.invoices.first.id}", href: "/merchants/#{@merchant.id}/invoices/#{@item5.invoices.first.id}")
     end
   end
 

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe 'merchant invoice index page' do
     expect(page).to have_content(invoice_item_3.invoice_id)
   end
 
-  it 'Each invoice id is a link to that invoice show page' do 
+  it 'Each invoice id is a link to that invoice show page' do
     visit "/merchants/#{merchant_1.id}/invoices"
 
-    expect(page).to have_link(invoice_item_1.invoice_id)
+    expect(page).to have_link("#{invoice_item_1.invoice_id}")
 
-    click_link invoice_item_1.invoice_id
-    
+    click_link "#{invoice_item_1.invoice_id}"
+
     expect(current_path).to eq("/merchants/#{merchant_1.id}/invoices/#{invoice_item_1.invoice_id}")
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -51,24 +51,25 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
-    describe '::incomplete' do
-      let!(:invoice_6) {FactoryBot.create(:invoice, created_at: "Sun, 9 Jan 2022 06:10:00 UTC +00:00")}
-      let!(:invoice_7) {FactoryBot.create(:invoice, created_at: "Mon, 10 Jan 2022 06:15:00 UTC +00:00")}
 
-      let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice: invoice_6, status: "pending")}
-      let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice: invoice_7, status: "packaged")}
-      let!(:invoice_item_3) {FactoryBot.create(:invoice_item, status: "shipped")}
-      let!(:invoice_item_4) {FactoryBot.create(:invoice_item, status: "shipped")}
+  end
 
-      it 'returns all of the invoices which havent yet shipped, in order from oldest to newest' do
-        expect(Invoice.incomplete).to include(invoice_item_1.invoice)
-        expect(Invoice.incomplete).to include(invoice_item_2.invoice)
-        expect(Invoice.incomplete).to include(@invoiceitem.invoice)
-      end
+  describe '::incomplete' do
+    let!(:invoice_6) {FactoryBot.create(:invoice, created_at: "Sun, 9 Jan 2022 06:10:00 UTC +00:00")}
+    let!(:invoice_7) {FactoryBot.create(:invoice, created_at: "Mon, 10 Jan 2022 06:15:00 UTC +00:00")}
 
-      it 'is ordered from oldest to newest' do
-        expect(Invoice.incomplete).to eq([invoice_item_1.invoice, invoice_item_2.invoice, @invoiceitem.invoice])
-      end
+    let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice: invoice_6, status: "pending")}
+    let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice: invoice_7, status: "packaged")}
+    let!(:invoice_item_3) {FactoryBot.create(:invoice_item, status: "shipped")}
+    let!(:invoice_item_4) {FactoryBot.create(:invoice_item, status: "shipped")}
+
+    it 'returns all of the invoices which havent yet shipped, in order from oldest to newest' do
+      expect(Invoice.incomplete).to include(invoice_item_1.invoice)
+      expect(Invoice.incomplete).to include(invoice_item_2.invoice)
+    end
+
+    it 'is ordered from oldest to newest' do
+      expect(Invoice.incomplete).to eq([invoice_item_1.invoice, invoice_item_2.invoice])
     end
   end
 end


### PR DESCRIPTION
This PR is for bug fixes that are coming from link tests in which the link tests should be reading strings and not integers.  These are mostly messages that appear while running rspec.  This also resolves conflicts with test data in the invoice model spec file.  

Lastly, this fixes the correct path for the invoice id links