### PR TITLE
Top five merchants

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,6 +2,7 @@ class Admin::MerchantsController < ApplicationController
   def index
     @enabled_merchants = Merchant.filter_merchant_status(1)
     @disabled_merchants = Merchant.filter_merchant_status(0)
+    @merchants = Merchant.all
   end
 
   def show

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,6 +31,6 @@ class Invoice < ApplicationRecord
   end
 
   def self.incomplete
-    joins(:invoice_items).where.not(invoice_items: { status: 2 }).order(:created_at).uniq
+    joins(:invoice_items).where.not(invoice_items: { status: 2 }).order(:created_at).distinct
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -40,7 +40,7 @@ class Merchant < ApplicationRecord
     items.where(status: status_enum)
   end
 
-  def self.top_5_merchants
+  def self.top_five_merchants
     joins(invoices: :invoice_items)
       .joins(:transactions)
       .where(transactions: { result: 1 })

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -50,7 +50,12 @@ class Merchant < ApplicationRecord
       .order(merchant_revenue: :desc)
   end
 
+
   def self.filter_merchant_status(status_enum)
     where(status: status_enum)
+  end
+
+  def revenue_by_merchant
+    Merchant.joins(:invoice_items).where(id: self.id).sum("invoice_items.unit_price * invoice_items.quantity")
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -40,6 +40,16 @@ class Merchant < ApplicationRecord
     items.where(status: status_enum)
   end
 
+  def self.top_5_merchants
+    joins(invoices: :invoice_items)
+      .joins(:transactions)
+      .where(transactions: { result: 1 })
+      .select("merchants.*, SUM(invoice_items.unit_price * invoice_items.quantity) AS merchant_revenue")
+      .group(:id)
+      .limit(5)
+      .order(merchant_revenue: :desc)
+  end
+
   def self.filter_merchant_status(status_enum)
     where(status: status_enum)
   end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -25,4 +25,11 @@
   <% end %>
 </div>
 
+
 <h3>Top Five Merchants By Revenue</h3>
+<div id="top-five-merchants">
+
+<% @merchants.top_5_merchants.each do |merchant| %>
+  <p><%= merchant.name %></p>
+<% end %>
+</div>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -24,3 +24,5 @@
     </div>
   <% end %>
 </div>
+
+<h3>Top Five Merchants By Revenue</h3>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -28,8 +28,9 @@
 
 <h3>Top Five Merchants By Revenue</h3>
 <div id="top-five-merchants">
-
 <% @merchants.top_five_merchants.each do |merchant| %>
-  <p><%= merchant.name %></p>
+  <p><%= link_to merchant.name, admin_merchant_path(merchant.id) %>
+  <%= require 'pry'; binding.pry %>
+  <%= merchant.invoices.first.total_revenue %></p>
 <% end %>
 </div>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -26,11 +26,12 @@
 </div>
 
 
-<h3>Top Five Merchants By Revenue</h3>
 <div id="top-five-merchants">
+<h3>Top Five Merchants By Revenue</h3>
 <% @merchants.top_five_merchants.each do |merchant| %>
-  <p><%= link_to merchant.name, admin_merchant_path(merchant.id) %>
-  <%= require 'pry'; binding.pry %>
-  <%= merchant.invoices.first.total_revenue %></p>
+  <div id="merchant-<%= merchant.id %>">
+    <p><%= link_to merchant.name, admin_merchant_path(merchant.id) %>
+      |  Total Revenue: $<%= merchant.revenue_by_merchant %></p>
+  </div>
 <% end %>
 </div>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -29,7 +29,7 @@
 <h3>Top Five Merchants By Revenue</h3>
 <div id="top-five-merchants">
 
-<% @merchants.top_5_merchants.each do |merchant| %>
+<% @merchants.top_five_merchants.each do |merchant| %>
   <p><%= merchant.name %></p>
 <% end %>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2022_01_08_023103) do
 
   # These are extensions that must be enabled in order to support this database

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -17,21 +17,29 @@ RSpec.describe 'admin merchants index' do
   let!(:item_6) {FactoryBot.create(:item, merchant_id: merchant_6.id)}
   let!(:item_7) {FactoryBot.create(:item, merchant_id: merchant_7.id)}
 
-  let!(:transaction_1) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_2) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_3) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_4) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_5) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_6) {FactoryBot.create(:transaction, result: "success")}
-  let!(:transaction_7) {FactoryBot.create(:transaction, result: "success")}
+  let!(:invoice_1) {FactoryBot.create(:invoice)}
+  let!(:invoice_2) {FactoryBot.create(:invoice)}
+  let!(:invoice_3) {FactoryBot.create(:invoice)}
+  let!(:invoice_4) {FactoryBot.create(:invoice)}
+  let!(:invoice_5) {FactoryBot.create(:invoice)}
+  let!(:invoice_6) {FactoryBot.create(:invoice)}
+  let!(:invoice_7) {FactoryBot.create(:invoice)}
 
-  let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice_id: transaction_1.invoice.id, item_id: item_1.id, quantity: 1, unit_price: 10)}
-  let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice_id: transaction_2.invoice.id, item_id: item_2.id, quantity: 2, unit_price: 10)}
-  let!(:invoice_item_3) {FactoryBot.create(:invoice_item, invoice_id: transaction_3.invoice.id, item_id: item_3.id, quantity: 3, unit_price: 10)}
-  let!(:invoice_item_4) {FactoryBot.create(:invoice_item, invoice_id: transaction_4.invoice.id, item_id: item_4.id, quantity: 4, unit_price: 10)}
-  let!(:invoice_item_5) {FactoryBot.create(:invoice_item, invoice_id: transaction_5.invoice.id, item_id: item_5.id, quantity: 5, unit_price: 10)}
-  let!(:invoice_item_6) {FactoryBot.create(:invoice_item, invoice_id: transaction_6.invoice.id, item_id: item_6.id, quantity: 6, unit_price: 10)}
-  let!(:invoice_item_7) {FactoryBot.create(:invoice_item, invoice_id: transaction_7.invoice.id, item_id: item_7.id, quantity: 7, unit_price: 10)}
+  let!(:transaction_1) {FactoryBot.create(:transaction, result: "success", invoice: invoice_1)}
+  let!(:transaction_2) {FactoryBot.create(:transaction, result: "success", invoice: invoice_2)}
+  let!(:transaction_3) {FactoryBot.create(:transaction, result: "success", invoice: invoice_3)}
+  let!(:transaction_4) {FactoryBot.create(:transaction, result: "success", invoice: invoice_4)}
+  let!(:transaction_5) {FactoryBot.create(:transaction, result: "success", invoice: invoice_5)}
+  let!(:transaction_6) {FactoryBot.create(:transaction, result: "success", invoice: invoice_6)}
+  let!(:transaction_7) {FactoryBot.create(:transaction, result: "success", invoice: invoice_7)}
+
+  let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice: invoice_1, item_id: item_1.id, quantity: 1, unit_price: 10)}
+  let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice: invoice_2, item_id: item_2.id, quantity: 2, unit_price: 10)}
+  let!(:invoice_item_3) {FactoryBot.create(:invoice_item, invoice: invoice_3, item_id: item_3.id, quantity: 3, unit_price: 10)}
+  let!(:invoice_item_4) {FactoryBot.create(:invoice_item, invoice: invoice_4, item_id: item_4.id, quantity: 4, unit_price: 10)}
+  let!(:invoice_item_5) {FactoryBot.create(:invoice_item, invoice: invoice_5, item_id: item_5.id, quantity: 5, unit_price: 10)}
+  let!(:invoice_item_6) {FactoryBot.create(:invoice_item, invoice: invoice_6, item_id: item_6.id, quantity: 6, unit_price: 10)}
+  let!(:invoice_item_7) {FactoryBot.create(:invoice_item, invoice: invoice_7, item_id: item_7.id, quantity: 7, unit_price: 10)}
   before(:each) do
     visit '/admin/merchants'
   end
@@ -106,6 +114,15 @@ RSpec.describe 'admin merchants index' do
         expect(invoice_item_6.item.merchant.name).to appear_before(invoice_item_5.item.merchant.name)
         expect(invoice_item_5.item.merchant.name).to appear_before(invoice_item_4.item.merchant.name)
         expect(invoice_item_4.item.merchant.name).to appear_before(invoice_item_3.item.merchant.name)
+      end
+    end
+
+    it 'has names as links which lead to the merchants show page' do
+      within "#top-five-merchants" do
+        save_and_open_page
+        click_link "#{invoice_item_7.item.merchant.name}"
+
+        expect(current_path).to eq("/admin/merchants/#{invoice_item_7.item.merchant.id}")
       end
     end
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe 'admin merchants index' do
 
     it 'has names as links which lead to the merchants show page' do
       within "#top-five-merchants" do
-        save_and_open_page
         click_link "#{invoice_item_7.item.merchant.name}"
 
         expect(current_path).to eq("/admin/merchants/#{invoice_item_7.item.merchant.id}")

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -5,6 +5,33 @@ RSpec.describe 'admin merchants index' do
   let!(:merchant_2) {FactoryBot.create(:merchant, status: "enabled")}
   let!(:merchant_3) {FactoryBot.create(:merchant, status: "enabled")}
   let!(:merchant_4) {FactoryBot.create(:merchant, status: "disabled")}
+  let!(:merchant_5) {FactoryBot.create(:merchant)}
+  let!(:merchant_6) {FactoryBot.create(:merchant)}
+  let!(:merchant_7) {FactoryBot.create(:merchant)}
+
+  let!(:item_1) {FactoryBot.create(:item, merchant_id: merchant_1.id)}
+  let!(:item_2) {FactoryBot.create(:item, merchant_id: merchant_2.id)}
+  let!(:item_3) {FactoryBot.create(:item, merchant_id: merchant_3.id)}
+  let!(:item_4) {FactoryBot.create(:item, merchant_id: merchant_4.id)}
+  let!(:item_5) {FactoryBot.create(:item, merchant_id: merchant_5.id)}
+  let!(:item_6) {FactoryBot.create(:item, merchant_id: merchant_6.id)}
+  let!(:item_7) {FactoryBot.create(:item, merchant_id: merchant_7.id)}
+
+  let!(:transaction_1) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_2) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_3) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_4) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_5) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_6) {FactoryBot.create(:transaction, result: "success")}
+  let!(:transaction_7) {FactoryBot.create(:transaction, result: "success")}
+
+  let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice_id: transaction_1.invoice.id, item_id: item_1.id, quantity: 1, unit_price: 10)}
+  let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice_id: transaction_2.invoice.id, item_id: item_2.id, quantity: 2, unit_price: 10)}
+  let!(:invoice_item_3) {FactoryBot.create(:invoice_item, invoice_id: transaction_3.invoice.id, item_id: item_3.id, quantity: 3, unit_price: 10)}
+  let!(:invoice_item_4) {FactoryBot.create(:invoice_item, invoice_id: transaction_4.invoice.id, item_id: item_4.id, quantity: 4, unit_price: 10)}
+  let!(:invoice_item_5) {FactoryBot.create(:invoice_item, invoice_id: transaction_5.invoice.id, item_id: item_5.id, quantity: 5, unit_price: 10)}
+  let!(:invoice_item_6) {FactoryBot.create(:invoice_item, invoice_id: transaction_6.invoice.id, item_id: item_6.id, quantity: 6, unit_price: 10)}
+  let!(:invoice_item_7) {FactoryBot.create(:invoice_item, invoice_id: transaction_7.invoice.id, item_id: item_7.id, quantity: 7, unit_price: 10)}
   before(:each) do
     visit '/admin/merchants'
   end
@@ -69,23 +96,17 @@ RSpec.describe 'admin merchants index' do
   end
 
   describe 'Top 5 Merchants Section' do
-    let!(:invoice_item_1) {FactoryBot.create(:invoice_item, quantity: 1, unit_price: 10)}
-    let!(:invoice_item_2) {FactoryBot.create(:invoice_item, quantity: 2, unit_price: 10)}
-    let!(:invoice_item_3) {FactoryBot.create(:invoice_item, quantity: 3, unit_price: 10)}
-    let!(:invoice_item_4) {FactoryBot.create(:invoice_item, quantity: 4, unit_price: 10)}
-    let!(:invoice_item_5) {FactoryBot.create(:invoice_item, quantity: 5, unit_price: 10)}
-    let!(:invoice_item_6) {FactoryBot.create(:invoice_item, quantity: 6, unit_price: 10)}
-    let!(:invoice_item_7) {FactoryBot.create(:invoice_item, quantity: 7, unit_price: 10)}
-
     it 'has a section for the top five merchants by total revenue' do
       expect(page).to have_content("Top Five Merchants By Revenue")
     end
 
     it 'has the names of each of the top 5 merchants' do
-      expect(invoice_item_7.item.merchant).to appear_before(invoice_item_6.item.merchant)
-      expect(invoice_item_6.item.merchant).to appear_before(invoice_item_5.item.merchant)
-      expect(invoice_item_5.item.merchant).to appear_before(invoice_item_4.item.merchant)
-      expect(invoice_item_4.item.merchant).to appear_before(invoice_item_3.item.merchant)
+      within "#top-five-merchants" do
+        expect(invoice_item_7.item.merchant.name).to appear_before(invoice_item_6.item.merchant.name)
+        expect(invoice_item_6.item.merchant.name).to appear_before(invoice_item_5.item.merchant.name)
+        expect(invoice_item_5.item.merchant.name).to appear_before(invoice_item_4.item.merchant.name)
+        expect(invoice_item_4.item.merchant.name).to appear_before(invoice_item_3.item.merchant.name)
+    end
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -67,4 +67,8 @@ RSpec.describe 'admin merchants index' do
   it 'has a link to create a new merchant on a new page' do
     expect(page).to have_link("Create a New Merchant", href: "/admin/merchants/new")
   end
+
+  it 'has a section for the top five merchants by total revenue' do
+    expect(page).to have_content("Top Five Merchants By Revenue")
+  end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -105,7 +105,9 @@ RSpec.describe 'admin merchants index' do
 
   describe 'Top 5 Merchants Section' do
     it 'has a section for the top five merchants by total revenue' do
-      expect(page).to have_content("Top Five Merchants By Revenue")
+      within "#top-five-merchants" do
+        expect(page).to have_content("Top Five Merchants By Revenue")
+      end
     end
 
     it 'has the names of each of the top 5 merchants' do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -125,5 +125,27 @@ RSpec.describe 'admin merchants index' do
         expect(current_path).to eq("/admin/merchants/#{invoice_item_7.item.merchant.id}")
       end
     end
+
+    it 'has the revenue generated from each merchant' do
+      within "#merchant-#{merchant_7.id}" do
+        expect(page).to have_content("Total Revenue: $70")
+      end
+
+      within "#merchant-#{merchant_6.id}" do
+        expect(page).to have_content("Total Revenue: $60")
+      end
+
+      within "#merchant-#{merchant_5.id}" do
+        expect(page).to have_content("Total Revenue: $50")
+      end
+
+      within "#merchant-#{merchant_4.id}" do
+        expect(page).to have_content("Total Revenue: $40")
+      end
+
+      within "#merchant-#{merchant_3.id}" do
+        expect(page).to have_content("Total Revenue: $30")
+      end
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -68,7 +68,24 @@ RSpec.describe 'admin merchants index' do
     expect(page).to have_link("Create a New Merchant", href: "/admin/merchants/new")
   end
 
-  it 'has a section for the top five merchants by total revenue' do
-    expect(page).to have_content("Top Five Merchants By Revenue")
+  describe 'Top 5 Merchants Section' do
+    let!(:invoice_item_1) {FactoryBot.create(:invoice_item, quantity: 1, unit_price: 10)}
+    let!(:invoice_item_2) {FactoryBot.create(:invoice_item, quantity: 2, unit_price: 10)}
+    let!(:invoice_item_3) {FactoryBot.create(:invoice_item, quantity: 3, unit_price: 10)}
+    let!(:invoice_item_4) {FactoryBot.create(:invoice_item, quantity: 4, unit_price: 10)}
+    let!(:invoice_item_5) {FactoryBot.create(:invoice_item, quantity: 5, unit_price: 10)}
+    let!(:invoice_item_6) {FactoryBot.create(:invoice_item, quantity: 6, unit_price: 10)}
+    let!(:invoice_item_7) {FactoryBot.create(:invoice_item, quantity: 7, unit_price: 10)}
+
+    it 'has a section for the top five merchants by total revenue' do
+      expect(page).to have_content("Top Five Merchants By Revenue")
+    end
+
+    it 'has the names of each of the top 5 merchants' do
+      expect(invoice_item_7.item.merchant).to appear_before(invoice_item_6.item.merchant)
+      expect(invoice_item_6.item.merchant).to appear_before(invoice_item_5.item.merchant)
+      expect(invoice_item_5.item.merchant).to appear_before(invoice_item_4.item.merchant)
+      expect(invoice_item_4.item.merchant).to appear_before(invoice_item_3.item.merchant)
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'admin merchants index' do
         expect(invoice_item_6.item.merchant.name).to appear_before(invoice_item_5.item.merchant.name)
         expect(invoice_item_5.item.merchant.name).to appear_before(invoice_item_4.item.merchant.name)
         expect(invoice_item_4.item.merchant.name).to appear_before(invoice_item_3.item.merchant.name)
-    end
+      end
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -61,7 +61,21 @@ RSpec.describe Merchant, type: :model do
         expect(Merchant.top_five_merchants).to eq(merchants)
       end
     end
+
+    describe '#revenue_by_merchant' do
+      it 'returns the total revenue of a merchant' do
+        expect(merchant_7.revenue_by_merchant).to eq(70)
+        expect(merchant_6.revenue_by_merchant).to eq(60)
+        expect(merchant_5.revenue_by_merchant).to eq(50)
+        expect(merchant_4.revenue_by_merchant).to eq(40)
+        expect(merchant_3.revenue_by_merchant).to eq(30)
+      end
+    end
+
+
   end
+
+
 
   describe 'instance methods' do
     let!(:merchant_1) {FactoryBot.create(:merchant)}

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -21,6 +21,48 @@ RSpec.describe Merchant, type: :model do
     end
   end
 
+  describe 'Top Five Merchants' do
+    let!(:merchant_1) {FactoryBot.create(:merchant, status: "disabled")}
+    let!(:merchant_2) {FactoryBot.create(:merchant, status: "enabled")}
+    let!(:merchant_3) {FactoryBot.create(:merchant, status: "enabled")}
+    let!(:merchant_4) {FactoryBot.create(:merchant, status: "disabled")}
+    let!(:merchant_5) {FactoryBot.create(:merchant)}
+    let!(:merchant_6) {FactoryBot.create(:merchant)}
+    let!(:merchant_7) {FactoryBot.create(:merchant)}
+
+    let!(:item_1) {FactoryBot.create(:item, merchant_id: merchant_1.id)}
+    let!(:item_2) {FactoryBot.create(:item, merchant_id: merchant_2.id)}
+    let!(:item_3) {FactoryBot.create(:item, merchant_id: merchant_3.id)}
+    let!(:item_4) {FactoryBot.create(:item, merchant_id: merchant_4.id)}
+    let!(:item_5) {FactoryBot.create(:item, merchant_id: merchant_5.id)}
+    let!(:item_6) {FactoryBot.create(:item, merchant_id: merchant_6.id)}
+    let!(:item_7) {FactoryBot.create(:item, merchant_id: merchant_7.id)}
+
+    let!(:transaction_1) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_2) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_3) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_4) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_5) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_6) {FactoryBot.create(:transaction, result: "success")}
+    let!(:transaction_7) {FactoryBot.create(:transaction, result: "success")}
+
+    let!(:invoice_item_1) {FactoryBot.create(:invoice_item, invoice_id: transaction_1.invoice.id, item_id: item_1.id, quantity: 1, unit_price: 10)}
+    let!(:invoice_item_2) {FactoryBot.create(:invoice_item, invoice_id: transaction_2.invoice.id, item_id: item_2.id, quantity: 2, unit_price: 10)}
+    let!(:invoice_item_3) {FactoryBot.create(:invoice_item, invoice_id: transaction_3.invoice.id, item_id: item_3.id, quantity: 3, unit_price: 10)}
+    let!(:invoice_item_4) {FactoryBot.create(:invoice_item, invoice_id: transaction_4.invoice.id, item_id: item_4.id, quantity: 4, unit_price: 10)}
+    let!(:invoice_item_5) {FactoryBot.create(:invoice_item, invoice_id: transaction_5.invoice.id, item_id: item_5.id, quantity: 5, unit_price: 10)}
+    let!(:invoice_item_6) {FactoryBot.create(:invoice_item, invoice_id: transaction_6.invoice.id, item_id: item_6.id, quantity: 6, unit_price: 10)}
+    let!(:invoice_item_7) {FactoryBot.create(:invoice_item, invoice_id: transaction_7.invoice.id, item_id: item_7.id, quantity: 7, unit_price: 10)}
+
+    describe '::top_five_merchants' do
+      it 'returns the top five merchants by revenue' do
+        merchants = [merchant_7, merchant_6, merchant_5, merchant_4, merchant_3]
+
+        expect(Merchant.top_five_merchants).to eq(merchants)
+      end
+    end
+  end
+
   describe 'instance methods' do
     let!(:merchant_1) {FactoryBot.create(:merchant)}
     let!(:merchant_2) {FactoryBot.create(:merchant)}


### PR DESCRIPTION
This is the user story for seeing the Top 5 merchants by revenue listed on the Admin merchants index page. 

This includes an AR query to find the top merchants by revenue and another to calculate their revenue.  

NOTE:  This pull request also resolves a previous AR query that should have .distinct listed at the end instead of .uniq.